### PR TITLE
feat: Add "logs" action to docker-compose commands

### DIFF
--- a/layers/docker.lua
+++ b/layers/docker.lua
@@ -204,6 +204,7 @@ local function docker_compose_generate_actions()
 		"start",
 		"stop",
 		"up",
+		"logs",
 	}
 	--- Accumulate all actions
 	local result = {


### PR DESCRIPTION
- Closes #4
- Updated the docker_compose_generate_actions function to include "logs" as a supported action.
- Enabled users to view logs of current services in docker-compose.